### PR TITLE
Add command that allows loading a single plugin if plugins contradict

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -7,7 +7,7 @@ mod plugin;
 use clap::{App, Arg, SubCommand};
 
 use std::fs::{create_dir_all, read_dir};
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::thread::sleep;
 use std::time::Duration;
@@ -49,10 +49,17 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 enum RunMode<'a> {
     Single(&'a Path),
-    All
+    All,
 }
 
-fn load_single_plugin<P>(plugins: &mut PluginCollection, plugins_path: &PathBuf, entry: P) -> Result<()> where P: AsRef<Path>  {
+fn load_single_plugin<P>(
+    plugins: &mut PluginCollection,
+    plugins_path: &PathBuf,
+    entry: P,
+) -> Result<()>
+where
+    P: AsRef<Path>,
+{
     unsafe {
         let plugin = plugins
             .load(plugins_path.join(entry.as_ref()))
@@ -167,16 +174,17 @@ fn execute() -> Result<()> {
             installer
                 .install(plugin_name, &plugins_path)
                 .map_err(|e| e.into())
-        },
+        }
         Some("single") => {
             let plugin_name = matches
                 .subcommand_matches("single")
                 .unwrap()
                 .value_of("plugin_name")
-                .unwrap().as_ref();
+                .unwrap()
+                .as_ref();
 
             run(&config, &plugins_path, RunMode::Single(plugin_name))
-        },
+        }
         _ => run(&config, &plugins_path, RunMode::All),
     }
 }


### PR DESCRIPTION
My use case for this is I want to write a plugin that autoappends clipboard contents to a buffer stored in memory on copy (so I can paste the entire buffer all at once without having to switch between the program I'm copying from and a scratch file such as Google Keep or Notepad).

This particular plugin should not be used in combination with other plugins. So my solution is to add a `single` command so I can just run whichever plugin I need at any given point :).

If this is not desirable to you, I'm open to other implementations.

I have confirmed this works as desired when testing these changes against your [amazon plugin](https://github.com/siketyan/autoclip/tree/main/plugin-amazon) with my tw-timestamp plugin [reimplementation](https://github.com/cr1901/tw-timestamp/tree/autoclip) in the plugins directory.